### PR TITLE
Document puppet_agent dep and add confdir_path param

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@
 fixtures:
   forge_modules:
     powershell: "puppetlabs/powershell"
+    puppet_agent: "puppetlabs/puppet_agent"
     stdlib: "puppetlabs/stdlib"
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -41,6 +41,14 @@ class { 'windows_puppet_certificates':
 }
 ```
 
+##### Specify the Puppet config directory
+
+```puppet
+class { 'windows_puppet_certificates':
+  'confdir_path' => 'c:/programdata/puppetlabs/puppet/etc',
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `windows_puppet_certificates` class.
@@ -73,6 +81,16 @@ private key, into the computer Personal certificate store.
 Default: false - importing a private key should be an explicit decision.
 
 Default value: `false`
+
+##### `confdir_path`
+
+Data type: `Optional[Stdlib::Windowspath]`
+
+If set, this path is used instead of the path provided by the
+`puppet_confdir` fact from the puppetlabs/puppet_agent module
+Default: undef
+
+Default value: `undef`
 
 ## Defined types
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
+      "name": "puppetlabs/puppet_agent",
+      "version_requirement": ">= 2.1.1 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.0 < 6.0.0"
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,44 +3,29 @@ require 'spec_helper'
 describe 'windows_puppet_certificates' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) do
-        facts.merge(
-          puppet_sslpaths: {
-            'privatedir' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/private',
-              'path_exists' => true,
-            },
-            'privatekeydir' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/private_keys',
-              'path_exists' => true,
-            },
-            'publickeydir' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/public_keys',
-              'path_exists' => true,
-            },
-            'certdir' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/certs',
-              'path_exists' => true,
-            },
-            'requestdir' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/certificate_requests',
-              'path_exists' => true,
-            },
-            'hostcrl' => {
-              'path' => 'C:/ProgramData/PuppetLabs/puppet/etc/ssl/crl.pem',
-              'path_exists' => true,
-            },
-          },
-        )
-      end
-
       context 'with defaults' do
+        let(:facts) do
+          facts.merge(puppet_confdir: 'C:/ProgramData/PuppetLabs/puppet/etc')
+        end
+
         it { is_expected.to compile.with_all_deps }
       end
 
       context 'with manage_client_cert => true' do
+        let(:facts) do
+          facts.merge(puppet_confdir: 'C:/ProgramData/PuppetLabs/puppet/etc')
+        end
+
         let(:params) do
           { 'manage_client_cert' => true }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
+
+      context 'with confdir_path => "c:/programdata/puppetlabs/puppet/etc"' do
+        let(:params) do
+          { 'confdir_path' => 'c:/programdata/puppetlabs/puppet/etc' }
         end
 
         it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
- Document dependancy on puppet_agent module
  - PR #1 put to use facts that I mistakenly thought came from the Puppet agent itself. This commit documents that those facts instead are provided by puppetlabs-puppet_agent via https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/master/lib/facter/settings.rb
- Incorporate `confdir_path` parameter from by PR #2