### PR TITLE
(maint) Fix typo for private key

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,7 +9,7 @@
 
 **Defined types**
 
-* [`windows_puppet_certificates::windows_certificate`](#windows_puppet_certificateswindows_certificate): 
+* [`windows_puppet_certificates::windows_certificate`](#windows_puppet_certificateswindows_certificate):
 
 ## Classes
 
@@ -17,7 +17,7 @@
 
 This module takes the Puppet Master CA certificate and Puppet Agent client
 certificate and imports them into the Windows Certificate Store and marks the
-public key as Not Exportable. This is useful to allow Windows applications to
+private key as Not Exportable. This is useful to allow Windows applications to
 consume these certificates in a Windows way. For example:
 - for client certificate based authentication in EAP in 802.1x
 - for automatically trusting the PE Console in web browsers

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 #
 # This module takes the Puppet Master CA certificate and Puppet Agent client
 # certificate and imports them into the Windows Certificate Store and marks the
-# public key as Not Exportable. This is useful to allow Windows applications to
+# private key as Not Exportable. This is useful to allow Windows applications to
 # consume these certificates in a Windows way. For example:
 # - for client certificate based authentication in EAP in 802.1x
 # - for automatically trusting the PE Console in web browsers


### PR DESCRIPTION
Previously the documentation said that the module marked the public key as not
exportable.  This was an error and should be private key.