### PR TITLE
(maint) Update author metadata and prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-12-19
+
+### Changed
+
+- Changed module author in metadata to puppetlabs
+
 ## [0.2.0] - 2019-12-19
+
+Note - This version was not released on the forge due to incorrect metadata
 
 ### Changed
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppetlabs-windows_puppet_certificates",
-  "version": "0.2.0",
-  "author": "glennsarti",
+  "version": "0.2.1",
+  "author": "puppetlabs",
   "summary": "A Puppet module to import the puppet certificates into the machine certificate store in Windows",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-windows_puppet_certificates.git",


### PR DESCRIPTION
Previously the metadata pointed to glennsarti (me) as the author. However this
is no longer true and breaks the module release process (via puppet-blacksmith).

This commit udpates the author to puppetlabs.

This commit also prepares the module for a patch release of 0.2.1.