### PR TITLE
(maint) Update Puppet VS Code Extension ID

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@
 fixtures:
   forge_modules:
     powershell: "puppetlabs/powershell"
+    pwshlib: "puppetlabs/pwshlib"
     stdlib: "puppetlabs/stdlib"
   symlinks:
     "windows_puppet_certificates": "#{source_dir}"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "jpogran.puppet-vscode",
+    "puppet.puppet-vscode",
     "rebornix.Ruby"
   ]
 }


### PR DESCRIPTION
This commit updates the configuration file to point to the official Puppet VS Code Extension `puppet.puppet-vscode`
