### PR TITLE
Fix Add-Type Compilation Error

### DIFF
--- a/templates/puppet_certs_common.ps1
+++ b/templates/puppet_certs_common.ps1
@@ -13,6 +13,18 @@ Function Out-Certificate {
 }
 
 Function Import-CSharpCode {
+
+  # When puppet is run via 'puppet agent -t', or via the service, when the
+  # account used to execute the run is the 'Local System' account, the temp
+  # directory is set to the value seen below in the if test. When this happens
+  # the Add-Type commandlet cannot compile the C# code in the type definition.
+  # The compilation process requires creating temp files, and that process is
+  # broken if the temp directory is not fixed first.
+  if( $env:tmp -eq "$env:windir\system32\config\systemprofile\AppData\Local\Temp") {
+    $env:tmp = "$env:windir\Temp"
+    $env:temp = "$env:windir\Temp"
+  }
+
   Write-Verbose "Importing C# code..."
 
   # From https://stackoverflow.com/questions/7400500/how-to-get-private-key-from-pem-file


### PR DESCRIPTION
When Puppet is run using the Local System account either via calling
`puppet agent -t` or when invoked by the service, the execution context
is a non-interactive session. When this happens the temp directory is
set to `C:\Windows\system32\config\systemprofile\AppData\Local\Temp`.

When the temp directory is set that way, `Add-Type` cannot compile any
C# code in the `-TypeDefinition` parameter. The reason is problems with
creating the temp files that are required to complete the compilation
process.

It looks like at some point in the past the behavior of
`System.CodeDom.Compiler.TempFileCollection` may have changed. When the
temp directory is incorrectly set, that assembly does not behave
correctly and causes errors.

This fix re-sets the temp directory to a usable location for that
assembly for the duration of the session, and allows `Add-Type` to
compile the required code.